### PR TITLE
Update AT_parser.h

### DIFF
--- a/STM32/030_AT_komendy_HD44780/src/AT_parser/AT_parser.c
+++ b/STM32/030_AT_komendy_HD44780/src/AT_parser/AT_parser.c
@@ -45,7 +45,8 @@ void AT_commands_decode(char* data)
 
 		// petla po wszystkich komendach - jesli nie mamy w sobie odpowiedniej komendy - wykonamy wszystkie iteracje
 		// w przypadku znalezienia komendy - opuszczamy petle
-		for(int i = 0; i < AT_commands_number; i++)
+		int i=0; //Utworzenie zmiennej i, aby była widoczna na zewnątrz
+		for( i = 0; i < AT_commands_number; i++)
 		{
 		    // porownanie odebranego napisu i komend z tablicy
 			if( strcmp(AT_command_array[i].cmd, data ) == 0 )
@@ -97,10 +98,15 @@ void AT_commands_decode(char* data)
 				break;
 			}
 		}
+		
+		// bledna komenda (taka której nazwa zaczyna się od AT+), ale nie ma jej w tabeli AT_cmd_array[]  - mozna dodac jakas defaultowy event w przyszlosci
+		// np do przeslania ramki ERROR
+		
+	
 	}
 	else
     {
-        // bledna komenda - mozna dodac jakas defaultowy event w przyszlosci
-		// np do przeslania ramki ERROR
+        // bledna komenda (taka której nazwa nie zaczyna się od AT+) - mozna dodac jakas defaultowy event w przyszlosci
+	// np do przeslania ramki ERROR
     }
 }

--- a/STM32/030_AT_komendy_HD44780/src/AT_parser/AT_parser.h
+++ b/STM32/030_AT_komendy_HD44780/src/AT_parser/AT_parser.h
@@ -9,9 +9,6 @@ typedef struct{
 	void (*callback_function)(char **, uint8_t );            // callback function pointer
 } t_cmd;
 
-//! prosty enum dla okreslenia czy funkcja przyjmuje parametry, czy nie
-enum{at_type_no_params, at_type_params};
-
 //! Maksymalna ilosc parametrow jakie bedziemy uzywac - wyznacza wielkosc tablicy z parametrami
 #define _MAX_PARAMETERS 15
 


### PR DESCRIPTION
Usunięcie enuma ponieważ nigdzie nie jest wykorzystywany
//! prosty enum dla okreslenia czy funkcja przyjmuje parametry, czy nie
enum{at_type_no_params, at_type_params};